### PR TITLE
Resolves: #2 Change the color of the status bar

### DIFF
--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="SharedAppTheme.NoActionBar">
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowBackground">@color/white</item>
+        <item name="android:statusBarColor">@color/white</item>
+        <item name="android:windowLightStatusBar">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
The color of the status bar is the same as the background when v23 or above,
if is not, the status bar will remain black.

Status bar with V23 or above
![screenshot-1560297906100](https://user-images.githubusercontent.com/16912316/59314759-57e57680-8c7c-11e9-8801-01e8590bfcf8.jpg)

Status bar with V22 or below
![screenshot-1560297768090](https://user-images.githubusercontent.com/16912316/59314738-40a68900-8c7c-11e9-951b-50026f1aa3d9.jpg)


