### PR TITLE
Add gradle properties config keys to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,16 @@ Please refer to the [contributing](./CONTRIBUTING.md) file to see our contributi
 ## Android Studio IDE setup
 
 Youst requires Android Studio version 3.5 or higher.
+
+### Gradle Properties
+
+**Note:** Please contact the project leader in order to get all the values for the gradle properties config constants.
+
+At your terminal, you will need to execute:
+
+```
+touch challenges/gradle.properties
+echo "POKEMON_API_URL=" >> challenges/gradle.properties
+```
+
+Now you can open the recently created `gradle.properties` file and add the values for all the keys.

--- a/challenges/src/main/java/mx/yellowme/youst/challenges/data/PokemonAPIServiceGenerator.kt
+++ b/challenges/src/main/java/mx/yellowme/youst/challenges/data/PokemonAPIServiceGenerator.kt
@@ -3,5 +3,4 @@ package mx.yellowme.youst.challenges.data
 import mx.yellowme.youst.challenges.BuildConfig
 import mx.yellowme.youst.core.data.BaseAPIServiceGenerator
 
-//TODO: Extract String URL
 class PokemonAPIServiceGenerator: BaseAPIServiceGenerator(BuildConfig.POKEMON_API_URL)


### PR DESCRIPTION
## What does this PR do?
- Modify README file to include gradle properties considerations
- Removing unused TODO comment at `PokemonAPIServiceGenerator`

## How should this be manually tested?
N/A

## What are the relevant tickets?
N/A

## Screenshots
N/A
