### PR TITLE
Add custom interpolator showcase with expanding card views

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     ]
     ext.versions = [
             kotlinVersion       : '1.3.31',
-            gradleVersion       : '3.5.0',
+            gradleVersion       : '3.6.1',
             navigation          : '2.1.0-beta02',
 
             // SDK and tools
@@ -16,7 +16,7 @@ buildscript {
             compileSdk          : 29,
             buildTools          : '29.0.1',
             appcompat           : '1.1.0-rc01',
-            constraintLayout    : '1.1.3',
+            constraintLayout    : '2.0.0-beta4',
             material            : '1.1.0-alpha09',
             emoji               : '1.0.0',
             flexbox             : '1.1.0',

--- a/core/src/main/java/mx/yellowme/youst/core/hooks/animations/AnimationListenerHelper.kt
+++ b/core/src/main/java/mx/yellowme/youst/core/hooks/animations/AnimationListenerHelper.kt
@@ -1,61 +1,50 @@
-@file:Suppress("unused")
-
 package mx.yellowme.youst.core.hooks.animations
 
-import android.animation.Animator
-import com.airbnb.lottie.LottieAnimationView
+import android.view.animation.Animation
 
-fun LottieAnimationView.setListener(init: AnimationListenerHelper.() -> Unit) {
+private typealias AnimationListener = (Animation) -> Unit
+
+fun Animation.setListener(init: AnimationListenerHelper.() -> Unit) {
     val listener = AnimationListenerHelper()
     listener.init()
-    addAnimatorListener(listener)
+    setAnimationListener(listener)
 }
 
-private typealias AnimListener = (Animator) -> Unit
-
-class AnimationListenerHelper : Animator.AnimatorListener {
-    private var animationStart: AnimListener? = null
-    private var animationEnd: AnimListener? = null
-    private var animationRepeat: AnimListener? = null
-    private var animationCancel: AnimListener? = null
+class AnimationListenerHelper : Animation.AnimationListener {
+    private var animationStart: AnimationListener? = null
+    private var animationEnd: AnimationListener? = null
+    private var animationRepeat: AnimationListener? = null
 
     //region Builder
 
-    fun onAnimationStart(onAnimationCancel: AnimListener) {
-        animationEnd = onAnimationCancel
+    fun onAnimationStart(onAnimationStart: AnimationListener) {
+        animationStart = onAnimationStart
     }
 
-    fun onAnimationEnd(onAnimationEnd: AnimListener) {
+    fun onAnimationEnd(onAnimationEnd: AnimationListener) {
         animationEnd = onAnimationEnd
     }
 
-    fun onAnimationRepeat(onAnimationRepeat: AnimListener) {
-        animationEnd = onAnimationRepeat
-    }
-
-    fun onAnimationCancel(onAnimationCancel: AnimListener) {
-        animationEnd = onAnimationCancel
+    fun onAnimationRepeat(onAnimationRepeat: AnimationListener) {
+        animationRepeat = onAnimationRepeat
     }
 
     //endregion
 
-    //region AnimatorListener
+    //region AnimationListener
 
-    override fun onAnimationStart(animation: Animator) {
+    override fun onAnimationStart(animation: Animation) {
         animationStart?.invoke(animation)
     }
 
-    override fun onAnimationEnd(animation: Animator) {
+    override fun onAnimationEnd(animation: Animation) {
         animationEnd?.invoke(animation)
     }
 
-    override fun onAnimationRepeat(animation: Animator) {
+    override fun onAnimationRepeat(animation: Animation) {
         animationRepeat?.invoke(animation)
     }
 
-    override fun onAnimationCancel(animation: Animator) {
-        animationCancel?.invoke(animation)
-    }
-
     //endregion
+
 }

--- a/core/src/main/java/mx/yellowme/youst/core/hooks/animations/AnimatorListenerHelper.kt
+++ b/core/src/main/java/mx/yellowme/youst/core/hooks/animations/AnimatorListenerHelper.kt
@@ -1,0 +1,61 @@
+@file:Suppress("unused")
+
+package mx.yellowme.youst.core.hooks.animations
+
+import android.animation.Animator
+import com.airbnb.lottie.LottieAnimationView
+
+fun LottieAnimationView.setListener(init: AnimatorListenerHelper.() -> Unit) {
+    val listener = AnimatorListenerHelper()
+    listener.init()
+    addAnimatorListener(listener)
+}
+
+private typealias AnimatorListener = (Animator) -> Unit
+
+class AnimatorListenerHelper : Animator.AnimatorListener {
+    private var animationStart: AnimatorListener? = null
+    private var animationEnd: AnimatorListener? = null
+    private var animationRepeat: AnimatorListener? = null
+    private var animationCancel: AnimatorListener? = null
+
+    //region Builder
+
+    fun onAnimationStart(onAnimationStart: AnimatorListener) {
+        animationEnd = onAnimationStart
+    }
+
+    fun onAnimationEnd(onAnimationEnd: AnimatorListener) {
+        animationEnd = onAnimationEnd
+    }
+
+    fun onAnimationRepeat(onAnimationRepeat: AnimatorListener) {
+        animationEnd = onAnimationRepeat
+    }
+
+    fun onAnimationCancel(onAnimationCancel: AnimatorListener) {
+        animationEnd = onAnimationCancel
+    }
+
+    //endregion
+
+    //region AnimatorListener
+
+    override fun onAnimationStart(animation: Animator) {
+        animationStart?.invoke(animation)
+    }
+
+    override fun onAnimationEnd(animation: Animator) {
+        animationEnd?.invoke(animation)
+    }
+
+    override fun onAnimationRepeat(animation: Animator) {
+        animationRepeat?.invoke(animation)
+    }
+
+    override fun onAnimationCancel(animation: Animator) {
+        animationCancel?.invoke(animation)
+    }
+
+    //endregion
+}

--- a/core/src/main/java/mx/yellowme/youst/core/utils/ActivityModuleHelper.kt
+++ b/core/src/main/java/mx/yellowme/youst/core/utils/ActivityModuleHelper.kt
@@ -70,6 +70,10 @@ object Activities {
         object BARCODE : AddressableActivity {
             override val className = "$PACKAGE_NAME.playground.ui.qrcode.BarcodeActivity"
         }
+
+        object Interpolator: AddressableActivity {
+            override val className = "$PACKAGE_NAME.playground.ui.interpolator.InterpolatorActivity"
+        }
      }
 
     object Challenges : AddressableActivity {

--- a/core/src/main/res/values-night/colors.xml
+++ b/core/src/main/res/values-night/colors.xml
@@ -8,11 +8,14 @@
     <color name="textColor">@color/haiti</color>
     <color name="iconColor">@color/white</color>
 
+    <color name="blue">#015075</color>
+    <color name="maroon">#390920</color>
+
     <color name="coral">#DE643F</color>
     <color name="turquoise">#04BA96</color>
     <color name="malibu">#0E9CFB</color>
     <color name="orchid">#A039CB</color>
-    <color name="cerise">#CB425A</color>
+    <color name="cerise">#8C3947</color>
     <color name="kiwi">#6CAF45</color>
     <color name="royal">#355AE1</color>
     <color name="violet">#660BCD</color>
@@ -50,5 +53,7 @@
     <color name="ghost">#383870</color>
     <color name="rock">#954B31</color>
     <color name="steel">#8FBDAA</color>
+
+    <color name="onahau">#374050</color>
 
 </resources>

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -38,6 +38,8 @@
     <color name="guitar_black">#6E6D84</color>
     <color name="guitar_secondary_black">#434255</color>
     <color name="guitar_light_black">#D4D1E4</color>
+    
+    <color name="onahau">#CEEEFF</color>
 
     <!--region NEW COLOR PALLET -->
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Aug 31 10:33:59 CDT 2019
+#Mon Apr 27 04:09:48 CDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/playground/src/main/AndroidManifest.xml
+++ b/playground/src/main/AndroidManifest.xml
@@ -88,6 +88,15 @@
 
         <!--endregion-->
 
+        <!--region Interpolator-->
+
+        <activity
+            android:name=".ui.interpolator.InterpolatorActivity"
+            android:parentActivityName=".PlaygroundActivity"
+            android:theme="@style/SharedAppTheme.NoActionBar.TransparentStatus" />
+
+        <!--endregion-->
+
     </application>
 
 </manifest>

--- a/playground/src/main/java/mx/yellowme/youst/playground/PlaygroundActivity.kt
+++ b/playground/src/main/java/mx/yellowme/youst/playground/PlaygroundActivity.kt
@@ -39,6 +39,9 @@ class PlaygroundActivity : GenericShowcaseActivity<PlaygroundElement>() {
                 PlaygroundElementType.BARCODE -> {
                     launch(intentTo(Activities.Playground.BARCODE))
                 }
+                PlaygroundElementType.INTERPOLATOR -> {
+                    launch(intentTo(Activities.Playground.Interpolator))
+                }
             }
         }
     }

--- a/playground/src/main/java/mx/yellowme/youst/playground/domain/PlaygroundElement.kt
+++ b/playground/src/main/java/mx/yellowme/youst/playground/domain/PlaygroundElement.kt
@@ -16,6 +16,7 @@ class PlaygroundElement(
                 "2" -> PlaygroundElementType.NEMO
                 "3" -> PlaygroundElementType.CHART
                 "4" -> PlaygroundElementType.BARCODE
+                "5" -> PlaygroundElementType.INTERPOLATOR
                 else -> throw RuntimeException("Unsupported challenge type for id: $id")
             }
         }
@@ -23,5 +24,5 @@ class PlaygroundElement(
 }
 
 enum class PlaygroundElementType {
-    JETPACK_NAVIGATION, NEMO, CHART, BARCODE
+    JETPACK_NAVIGATION, NEMO, CHART, BARCODE, INTERPOLATOR
 }

--- a/playground/src/main/java/mx/yellowme/youst/playground/ui/interpolator/InterpolatorActivity.kt
+++ b/playground/src/main/java/mx/yellowme/youst/playground/ui/interpolator/InterpolatorActivity.kt
@@ -1,0 +1,21 @@
+package mx.yellowme.youst.playground.ui.interpolator
+
+import android.os.Bundle
+import kotlinx.android.synthetic.main.interpolator.easeCardView
+import mx.yellowme.youst.core.hooks.BaseActivity
+import mx.yellowme.youst.playground.R
+import mx.yellowme.youst.playground.ui.widgets.ResizableCardView.Interpolator.EASE
+
+class InterpolatorActivity : BaseActivity() {
+
+    override val layoutId = R.layout.interpolator
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        with(easeCardView) {
+            interpolator = EASE
+            duration = 600
+        }
+    }
+}

--- a/playground/src/main/java/mx/yellowme/youst/playground/ui/widgets/ResizableCardView.kt
+++ b/playground/src/main/java/mx/yellowme/youst/playground/ui/widgets/ResizableCardView.kt
@@ -1,0 +1,164 @@
+package mx.yellowme.youst.playground.ui.widgets
+
+import android.animation.AnimatorSet
+import android.animation.ValueAnimator
+import android.content.Context
+import android.util.AttributeSet
+import android.view.animation.AnimationUtils
+import android.view.animation.LinearInterpolator
+import androidx.core.animation.doOnEnd
+import androidx.core.animation.doOnStart
+import androidx.core.content.res.getResourceIdOrThrow
+import com.google.android.material.card.MaterialCardView
+import kotlinx.android.synthetic.main.resizable_card_view.view.cardDescription
+import kotlinx.android.synthetic.main.resizable_card_view.view.cardTitle
+import kotlinx.android.synthetic.main.resizable_card_view.view.header
+import mx.yellowme.youst.core.extensions.consumeTypeArray
+import mx.yellowme.youst.core.extensions.dp
+import mx.yellowme.youst.core.extensions.fadeIn
+import mx.yellowme.youst.core.extensions.fadeOut
+import mx.yellowme.youst.core.extensions.inflate
+import mx.yellowme.youst.core.hooks.animations.setListener
+import mx.yellowme.youst.playground.R
+import mx.yellowme.youst.playground.ui.widgets.ResizableCardView.Interpolator.EASE
+import mx.yellowme.youst.playground.ui.widgets.ResizableCardView.Interpolator.LINEAR
+import mx.yellowme.youst.playground.ui.widgets.ResizableCardView.Interpolator.valueOf
+
+/**
+ * Custom implementation of a [MaterialCardView] that expands and contracts with a click event.
+ * The duration of the expansion animation, as well as the value interpolation, are customizable.
+ * The interpolator can be either linear or ease.
+ */
+class ResizableCardView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : MaterialCardView(context, attrs, defStyleAttr) {
+    var duration: Long =
+        DEFAULT_DURATION.toLong()
+    lateinit var interpolator: Interpolator
+    var cardBackground: Int = R.drawable.blue_gradient
+        set(backgroundResource) {
+            updateHeaderBackground(backgroundResource)
+        }
+    private var title: String = ""
+        set(text) {
+            field = text
+            cardTitle.text = text
+        }
+    private var description: String = ""
+        set(text) {
+            field = text
+            cardDescription.text = text
+        }
+    private var isAnimationFinished = true
+    private var isExpanded = false
+
+    init {
+        initCardView()
+        setSizeChangeAnimation()
+        attrs?.consumeTypeArray(context, R.styleable.ResizableCardView) {
+            title = getString(R.styleable.ResizableCardView_resizableCardTitle) ?: ""
+            description = getString(R.styleable.ResizableCardView_resizableCardDescription) ?: ""
+            interpolator =
+                valueOf(
+                    getString(R.styleable.ResizableCardView_resizableCardInterpolator)
+                        ?: LINEAR.name
+                )
+            duration =
+                getInt(R.styleable.ResizableCardView_expandDuration, DEFAULT_DURATION).toLong()
+            cardBackground =
+                getResourceIdOrThrow(R.styleable.ResizableCardView_resizableCardBackground)
+        }
+    }
+
+    private fun setSizeChangeAnimation() {
+        setOnClickListener {
+            val cardWidth = width
+            val cardHeight = height
+            val cornerRadius = radius
+
+            val widthAnimator =
+                ValueAnimator.ofInt(cardWidth, cardWidth + if (isExpanded) (-80).dp else 80.dp)
+                    .apply {
+                        addUpdateListener { animator ->
+                            val value = animator.animatedValue as Int
+                            layoutParams.width = value
+                            requestLayout()
+                        }
+                    }
+
+            val heightAnimator =
+                ValueAnimator.ofInt(cardHeight, cardHeight + if (isExpanded) (-80).dp else 80.dp)
+                    .apply {
+                        addUpdateListener { animator ->
+                            val value = animator.animatedValue as Int
+                            layoutParams.height = value
+                            requestLayout()
+                        }
+                    }
+
+            val cornerAnimator =
+                ValueAnimator.ofFloat(
+                    cornerRadius,
+                    cornerRadius + if (isExpanded) 6.dp.toFloat() else (-6).dp.toFloat()
+                )
+                    .apply {
+                        addUpdateListener { animator ->
+                            val value = animator.animatedValue as Float
+                            radius = value
+                            requestLayout()
+                        }
+                    }
+
+            AnimatorSet().apply {
+                if (isAnimationFinished) {
+                    playTogether(widthAnimator, heightAnimator, cornerAnimator)
+                    interpolator = when (this@ResizableCardView.interpolator) {
+                        LINEAR -> LinearInterpolator()
+                        EASE -> AnimationUtils.loadInterpolator(context, R.anim.ease)
+                    }
+                    duration = this@ResizableCardView.duration
+                    doOnStart {
+                        isAnimationFinished = false
+                    }
+                    doOnEnd {
+                        cardDescription.startAnimation(fadeIn())
+                        isExpanded = !isExpanded
+                        isAnimationFinished = true
+                    }
+                    startCardAnimation()
+                }
+            }
+        }
+    }
+
+    private fun initCardView() {
+        inflate(R.layout.resizable_card_view, context)
+        cardElevation = 20.dp.toFloat()
+        updateHeaderBackground(cardBackground)
+    }
+
+    private fun updateHeaderBackground(id: Int) {
+        header.background = context.getDrawable(id)
+    }
+
+    private fun AnimatorSet.startCardAnimation() {
+        val descriptionFadeOut = fadeOut().apply {
+            setListener {
+                onAnimationEnd {
+                    this@startCardAnimation.start()
+                }
+            }
+        }
+        cardDescription.startAnimation(descriptionFadeOut)
+    }
+
+    enum class Interpolator {
+        LINEAR, EASE
+    }
+
+    companion object {
+        const val DEFAULT_DURATION = 500
+    }
+}

--- a/playground/src/main/res/anim/ease.xml
+++ b/playground/src/main/res/anim/ease.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<pathInterpolator xmlns:android="http://schemas.android.com/apk/res/android"
+    android:controlX1="0.8"
+    android:controlX2="0.35"
+    android:controlY1="0"
+    android:controlY2="1" />

--- a/playground/src/main/res/drawable/blue_gradient.xml
+++ b/playground/src/main/res/drawable/blue_gradient.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <gradient
+        android:angle="315"
+        android:endColor="@color/haiti"
+        android:startColor="@color/blue" />
+
+</shape>

--- a/playground/src/main/res/drawable/card_showcase_background.xml
+++ b/playground/src/main/res/drawable/card_showcase_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <gradient
+        android:angle="315"
+        android:endColor="@color/onahau"
+        android:startColor="@color/white" />
+
+</shape>

--- a/playground/src/main/res/drawable/red_gradient.xml
+++ b/playground/src/main/res/drawable/red_gradient.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+
+    <gradient
+        android:angle="315"
+        android:endColor="@color/maroon"
+        android:startColor="@color/cerise" />
+
+</shape>

--- a/playground/src/main/res/layout/interpolator.xml
+++ b/playground/src/main/res/layout/interpolator.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/card_showcase_background"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
+
+    <mx.yellowme.youst.playground.ui.widgets.ResizableCardView
+        android:id="@+id/linearCardView"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/dimen_60"
+        app:cardBackground="@drawable/blue_gradient"
+        app:cardCornerRadius="@dimen/dimen_12"
+        app:cardDescription="@string/linear_interpolator_description"
+        app:cardTitle="@string/linear_interpolator_title"
+        app:layout_constraintBottom_toTopOf="@id/middleGuide"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <mx.yellowme.youst.playground.ui.widgets.ResizableCardView
+        android:id="@+id/easeCardView"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/dimen_60"
+        app:cardBackground="@drawable/red_gradient"
+        app:cardCornerRadius="@dimen/dimen_12"
+        app:cardDescription="@string/ease_interpolator_description"
+        app:cardTitle="@string/ease_interpolator_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/middleGuide">
+
+    </mx.yellowme.youst.playground.ui.widgets.ResizableCardView>
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/middleGuide"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/playground/src/main/res/layout/resizable_card_view.xml
+++ b/playground/src/main/res/layout/resizable_card_view.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/linearCardView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <View
+            android:id="@+id/header"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/dimen_100"
+            tools:background="@drawable/blue_gradient" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/dimen_10">
+
+            <TextView
+                android:id="@+id/cardTitle"
+                style="@style/TextAppearance.MaterialComponents.Headline6"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="@string/linear_interpolator_title" />
+
+            <TextView
+                android:id="@+id/cardDescription"
+                style="@style/TextAppearance.MaterialComponents.Body2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/dimen_5"
+                tools:text="@string/linear_interpolator_description" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/playground/src/main/res/values/attrs_resizable_card.xml
+++ b/playground/src/main/res/values/attrs_resizable_card.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="ResizableCardView">
+        <attr name="resizableCardInterpolator" format="enum">
+            <enum name="linear" value="0" />
+            <enum name="ease" value="1" />
+        </attr>
+        <attr name="expandDuration" format="integer" />
+        <attr name="resizableCardBackground" format="reference|color" />
+        <attr name="resizableCardTitle" format="string" />
+        <attr name="resizableCardDescription" format="string" />
+    </declare-styleable>
+</resources>

--- a/playground/src/main/res/values/strings.xml
+++ b/playground/src/main/res/values/strings.xml
@@ -44,4 +44,9 @@
     <string name="showcases_label">Chart showcases</string>
 
     <string name="scan_photo_label">Scan</string>
+
+    <string name="linear_interpolator_title">Linear Interpolator</string>
+    <string name="linear_interpolator_description">This is a CardView controlled by a LinearInterpolator. Click on it and see how it changes size with a constant speed.</string>
+    <string name="ease_interpolator_title">Ease Interpolator</string>
+    <string name="ease_interpolator_description">This is a CardView controlled by a PathInterpolator configured to provide an easing motion. Click on it and see how it changes size with an easing motion.</string>
 </resources>

--- a/playground/src/main/resources/playground.json
+++ b/playground/src/main/resources/playground.json
@@ -22,5 +22,11 @@
     "title": "QR scanner",
     "subtitle": "Implementation of FotoApparat library and Barcode API.\n\nScan QR codes using this component.",
     "paletteColor": "PINK_GLAMOUR"
+  },
+  {
+    "id": "5",
+    "title": "Interpolator",
+    "subtitle": "Showcase of different types of interpolators.",
+    "paletteColor": "SKIRRET_GREEN"
   }
 ]


### PR DESCRIPTION
## What does this PR do?
- New showcase in Playground: Interpolator
- Custom expandable card view
- Custom ease interpolator
- Add an animation listener DSL

## How should this be manually tested?
Open the Interpolator showcase in Youst's Playground and click on the cards.

## Screenshots
![interpolators_low](https://user-images.githubusercontent.com/42198041/81008810-27b94000-8e19-11ea-866e-e99af39c083b.gif)
